### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ MacOS
 ### Windows
 - **Download .exe**: Coming Soon!
 
-### Windows
+### Linux (Debian/Ubuntu)
 - **Download .deb**: Coming Soon!
 
 ### iOS


### PR DESCRIPTION
Fixes a small error in the README.md where the Windows section was mistakenly duplicated. The second "Windows" heading actually referred to a .deb package, which is intended for Linux (Debian/Ubuntu) systems, not Windows.