### PR TITLE
Add GitHub Actions workflow for unsigned iOS IPA builds

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,127 @@
+name: Build iOS Production IPA (unsigned)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: openspot-mobile
+
+    env:
+      CI: "1"
+      NODE_ENV: "production"
+      APP_NAME: "OpenSpot"
+      SCHEME_NAME: "OpenSpot"
+      EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
+      EXPO_PUBLIC_YT_API_INSTANCES: ${{ secrets.EXPO_PUBLIC_YT_API_INSTANCES }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: openspot-mobile/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Remove Expo Dev Tools
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            delete pkg.dependencies['expo-dev-client'];
+            delete pkg.dependencies['expo-dev-menu'];
+            delete pkg.dependencies['expo-dev-launcher'];
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+            
+            const app = JSON.parse(fs.readFileSync('app.json', 'utf8'));
+            app.expo.plugins = app.expo.plugins.filter(p => {
+              const name = typeof p === 'string' ? p : p[0];
+              return !['expo-dev-client', 'expo-dev-menu', 'expo-dev-launcher'].includes(name);
+            });
+            fs.writeFileSync('app.json', JSON.stringify(app, null, 2));
+          "
+          rm -rf node_modules/expo-dev-*
+
+      - name: Reinstall dependencies
+        run: npm ci
+
+      - name: Prebuild iOS
+        run: npx expo prebuild --platform ios --clean
+
+      - name: Install Pods
+        run: |
+          cd ios
+          export RCT_NEW_ARCH_ENABLED=1
+          pod install --repo-update
+
+      - name: Bundle JS (Hermes production)
+        run: |
+          npx expo export:embed \
+            --platform ios \
+            --entry-file index.js \
+            --bundle-output ios/main.jsbundle \
+            --assets-dest ios \
+            --dev false \
+            --reset-cache \
+            --bytecode
+
+      - name: Fix Xcode Build Phase
+        run: |
+          sed -i '' 's/--dev true/--dev false/g' ios/*/project.pbxproj || true
+
+      - name: Build Archive (unsigned)
+        run: |
+          cd ios
+          xcodebuild archive \
+            -workspace $APP_NAME.xcworkspace \
+            -scheme $SCHEME_NAME \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination 'generic/platform=iOS' \
+            -archivePath build/OpenSpot.xcarchive \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_STYLE=Manual \
+            DEVELOPMENT_TEAM="" \
+            PROVISIONING_PROFILE_SPECIFIER="" \
+            ONLY_ACTIVE_ARCH=NO
+
+      - name: Verify bundle inside app
+        run: |
+          APP_PATH=$(find ios/build/OpenSpot.xcarchive/Products/Applications -name "*.app" | head -1)
+
+          echo "App: $APP_PATH"
+
+          if [ ! -f "$APP_PATH/main.jsbundle" ]; then
+            echo "Copiando bundle manualmente..."
+            cp ios/main.jsbundle "$APP_PATH/main.jsbundle"
+          fi
+
+          ls -la "$APP_PATH"
+
+      - name: Package IPA
+        run: |
+          cd ios
+          APP_PATH=$(find build/OpenSpot.xcarchive/Products/Applications -name "*.app" | head -1)
+
+          mkdir -p build/Payload
+          cp -r "$APP_PATH" build/Payload/
+
+          cd build
+          zip -r OpenSpot.ipa Payload
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenSpot-IPA
+          path: openspot-mobile/ios/build/OpenSpot.ipa

--- a/openspot-mobile/app.json
+++ b/openspot-mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "OpenSpot",
     "slug": "OpenSpot",
-    "version": "3.1.0",
+    "version": "3.1.3",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "openspot",
@@ -11,6 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.devx.openspot",
+      "buildNumber": "37",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to automatically build an unsigned iOS IPA for OpenSpot using macOS runners.

## Includes

- Expo iOS prebuild process
- CocoaPods dependency installation
- Release archive generation
- IPA packaging
- Upload of the generated IPA as a workflow artifact

## Why

The project currently does not have an automated iOS build pipeline. This workflow provides a reproducible way to generate iOS builds and helps enable future iOS distribution.

## Ideal Use Cases

The generated unsigned IPA is especially useful for alternative iOS sideloading methods such as SideStore and AltStore.

## Notes

- This workflow generates an unsigned IPA intended for sideloading or manual signing.
- Added iOS `buildNumber` to app configuration.
- Maintainers may adjust signing/export settings later for official releases.

## Possible Future Improvements

I’d also be happy to help implement an optimized auto-release pipeline in the future, such as triggering builds only when the app version changes and automatically publishing IPA files to GitHub Releases to reduce unnecessary Actions usage.