### PR TITLE
docs: fix typos and incorrect directory paths in README, ROADMAP, CHA…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ This is the most stable version so far, with no known bugs and improved overall 
 ### New Features
 
 * **i18n**: Supports 8 languages (de, en, es, fr, he, hi, ru, zh).
-* **API**: Supports Savan API and YouTube API.
-* **Search**: Users can now search public playlists, albums, and artists (Savan API only).
+* **API**: Supports Saavn API and YouTube API.
+* **Search**: Users can now search public playlists, albums, and artists (Saavn API only).
 * **UI**: Revamped UI with a new welcome screen and settings screen.
 * **Theme**: Dark mode, light mode, and auto mode supported.
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ This monorepo delivers **two fully independent music streaming apps** built with
 
 | App | Platforms | Framework | Location |
 |-----|-----------|-----------|----------|
-| 📱 **Mobile** | Android, iOS *(coming)* | React Native + Expo | `openspot-music-mobile/` |
-| 🖥️ **Desktop** | macOS, Windows/Linux *(coming)* | Electron + React | `openspot-music-electron/` |
+| 📱 **Mobile** | Android, iOS *(coming)* | React Native + Expo | `openspot-mobile/` |
+| 🖥️ **Desktop** | macOS, Windows/Linux *(coming)* | Electron + React | `openspot-desktop/` |
 
 Both apps share the same powerful streaming core, giving you a seamless listening experience across all your devices.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,9 +3,9 @@
 This document outlines planned features and upcoming improvements for OpenSpot. Contributions are welcome!
 
 
-## Todo Fixes and features (ANDRIOD APP v3.1.0)
+## Todo Fixes and features (ANDROID APP v3.1.0)
 - fix [issue #50](https://github.com/BlackHatDevX/openspot-music-app/issues/50)
-- add [Türkiye language support](https://x.com/TraderEXP_/status/2049183639615811804?s=20)
+- ~~add [Türkiye language support](https://x.com/TraderEXP_/status/2049183639615811804?s=20)~~ ✅ Added in v3.1.0
 - fix downloads issue
 
 


### PR DESCRIPTION
## What
Fixed typos and outdated information across 3 documentation files.

## Changes

### README.md
| Line | Before | After |
|------|--------|-------|
| 145 | `openspot-music-mobile/` | `openspot-mobile/` |
| 146 | `openspot-music-electron/` | `openspot-desktop/` |

The directory names in the overview table didn't match the actual folder names in the repo.

### ROADMAP.md
| Line | Before | After |
|------|--------|-------|
| 6 | `ANDRIOD` | `ANDROID` |
| 8 | Turkish support listed as TODO | Marked as ✅ completed (shipped in v3.1.0 per CHANGELOG) |

### CHANGELOG.md
| Line | Before | After |
|------|--------|-------|
| 57-58 | `Savan API` | `Saavn API` |

Saavn (JioSaavn) is the correct service name.

## Files changed
`README.md`, `ROADMAP.md`, `CHANGELOG.md` — docs only, no code changes.
