### PR TITLE
Docs/ios setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Used for SideStore (recommended).
 
 LiveContainer may support importing the same URL as a Source depending on your setup.
 
-Copy and paste this URL into SideStore / LiveContainer sources: `https://raw.githubusercontent.com/CesarGarza55/openspot-music-app/main/apps.json`
+Copy and paste this URL into SideStore / LiveContainer sources: `https://raw.githubusercontent.com/BlackHatDevX/openspot-music-app/main/apps.json`
 
 
 This allows:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,50 @@
 
 <br>
 
+## 🍎 iOS Installation (SideStore / LiveContainer)
+
+The iOS build is distributed as an **unsigned IPA** and requires sideloading.
+
+</div>
+
+## 📌 SideStore
+
+- https://sidestore.io/
+- https://docs.sidestore.io/
+
+Steps:
+1. Install SideStore  
+2. Complete initial pairing (one-time computer setup)  
+3. Add OpenSpot by pasting the apps.json URL into SideStore sources
+4. Install directly from SideStore  
+
+---
+
+## 📌 LiveContainer
+
+https://github.com/LiveContainer/LiveContainer
+
+Supports running sideloaded apps in isolated environments.  
+OpenSpot can be installed by importing the IPA file directly or using apps.json if your setup supports external sources.
+
+---
+
+### 📦 apps.json Feed
+
+Used for SideStore (recommended).
+
+LiveContainer may support importing the same URL as a Source depending on your setup.
+
+Copy and paste this URL into SideStore / LiveContainer sources: `https://raw.githubusercontent.com/CesarGarza55/openspot-music-app/main/apps.json`
+
+
+This allows:
+- Direct installation
+- Easy updates
+- No manual IPA downloads
+
+---
+
 ### 🖥️ **Desktop**
 
 🍎 **macOS (Apple Silicon)**

--- a/apps.json
+++ b/apps.json
@@ -1,0 +1,23 @@
+{
+  "name": "OpenSpot Music",
+  "identifier": "com.devx.openspot",
+  "apps": [
+    {
+      "name": "OpenSpot Music",
+      "bundleIdentifier": "com.devx.openspot",
+      "developerName": "BlackHatDevX",
+      "subtitle": "Stream & download high-quality music",
+      "localizedDescription": "Stream & download high-quality music, free, no ads, no login.",
+      "iconURL": "https://github.com/user-attachments/assets/9f56500d-d950-48c6-a362-bcbc74be88cb",
+      "tintColor": "1db954",
+      "versions": [
+        {
+          "version": "3.1.4",
+          "date": "2026-05-05T13:00:00Z",
+          "downloadURL": "https://github.com/BlackHatDevX/openspot-music-app/releases/download/v3.1.4/OpenSpot-3.1.4-release.ipa",
+          "size": 11429478
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 📦 PR Description

This pull request introduces updates to the **iOS distribution setup for OpenSpot Music**, improving clarity and usability of the installation process via sideloading tools.

---

## ✨ Changes included


- Improved **SideStore installation instructions**
- Clarified how to add OpenSpot using the **apps.json source**
- Added explicit usage flow for:
  - SideStore setup
  - IPA installation workflow
- Improved explanation of **LiveContainer compatibility**
- Enhanced readability of iOS installation section
- Updated `apps.json` usage description for better user understanding

---

## 🔗 apps.json source

The app can now be installed via SideStore-compatible sources using:
https://raw.githubusercontent.com/BlackHatDevX/openspot-music-app/main/apps.json


---

## 📱 Goal

Make iOS installation more beginner-friendly and less ambiguous, especially for users unfamiliar with SideStore or sideloading workflows.

---

## ⚠️ Notes

- No AltStore dependency included (SideStore only)
- LiveContainer support is documented as optional / experimental
- No functional changes to the app itself, only documentation improvements